### PR TITLE
Add redirect page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset=utf-8>
+<style>
+body {
+  margin: 3em;
+
+  font-family: Helvetica, Arial, sans-serif;
+}
+</style>
+<title>GOV.UK Prototype Kit training has moved - GOV.UK Prototype Kit</title>
+</head>
+<body>
+<main>
+  <h1>GOV.UK Prototype Kit training has moved</h1>
+
+  <p>Looking for the GOV.UK Prototype Kit training website?</p>
+
+  <p>Training and other guidance for the Prototype Kit has moved to <a href="https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples">https://govuk-prototype-kit.herokuapp.com/docs/tutorials-and-examples</a></p>
+</main>
+</body>
+</html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -16,6 +16,15 @@ http {
 
   server {
     listen {{port}} default_server;
-    return 301 https://govuk-prototype-kit.herokuapp.com$request_uri;
+
+    error_page 404 /404.html;
+
+    location /404.html {
+      root .;
+    }
+
+    location / {
+      return 404;
+    }
   }
 }


### PR DESCRIPTION
We want to direct users to the tutorials and examples on the Prototype Kit website, and inform them that the previous location is no longer valid. The easiest way to do this is to serve a custom 404 page that shows for any request, pointing them towards the current documentation site. This won't redirect automatically, but will give users enough information to update their bookmarks or guidance as necessary.

You can see what the page looks/will look like at https://prototype-kit-training-redirect.cloudapps.digital/

---

This is part of https://github.com/alphagov/govuk-prototype-kit/issues/1275. Once this has been approved and merged I will deploy it by hand, and record the process on that ticket.